### PR TITLE
fix: Route53 Alias record so that it uses the correct S3 endpoint regardless of the region the bucket is created in

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_route53_record" "domains" {
   type    = "A"
 
   alias {
-    name                   = "s3-website.${aws_s3_bucket.route53_http_redirect_bucket.region}.amazonaws.com"
+    name                   = aws_s3_bucket_website_configuration.route53_http_redirect_webconf.website_domain
     zone_id                = aws_s3_bucket.route53_http_redirect_bucket.hosted_zone_id
     evaluate_target_health = true
   }


### PR DESCRIPTION
The prior approach doesn't work for buckets in:
us-east-1
us-west-1
us-west-2

As well as some other regions. A full list of the ones using `s3-website-` instead of `s3-website.` can be found here:

https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints